### PR TITLE
Upgrade to latest version of libipld

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
+ "serde",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,11 +1431,25 @@ dependencies = [
  "cached",
  "fnv",
  "libipld-cbor",
- "libipld-core",
- "libipld-macro",
+ "libipld-core 0.14.0",
+ "libipld-macro 0.14.0",
  "log",
  "multihash 0.16.3",
  "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ccd6b8ffb3afee7081fcaec00e1b099fd1c7ccf35ba5729d88538fcc3b4599"
+dependencies = [
+ "fnv",
+ "libipld-core 0.16.0",
+ "libipld-macro 0.16.0",
+ "log",
+ "multihash 0.18.1",
  "thiserror",
 ]
 
@@ -1433,7 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd1ab68c9d26f20c7d0dfea6eecbae8c00359875210001b33ca27d4a02f3d09"
 dependencies = [
  "byteorder",
- "libipld-core",
+ "libipld-core 0.14.0",
  "thiserror",
 ]
 
@@ -1444,10 +1471,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.8.6",
  "core2",
  "multibase",
  "multihash 0.16.3",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acd707e8d8b092e967b2af978ed84709eaded82b75effe6cb6f6cc797ef8158"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
  "thiserror",
 ]
 
@@ -1457,7 +1498,16 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852c011562ae5059b67c3a917f9f5945af5a68df8e39ede4444fff33274d25e2"
 dependencies = [
- "libipld-core",
+ "libipld-core 0.14.0",
+]
+
+[[package]]
+name = "libipld-macro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71171c54214f866ae6722f3027f81dff0931e600e5a61e6b1b6a49ca0b5ed4ae"
+dependencies = [
+ "libipld-core 0.16.0",
 ]
 
 [[package]]
@@ -1512,7 +1562,8 @@ dependencies = [
  "fnv",
  "futures",
  "lazy_static",
- "libipld",
+ "libipld 0.14.0",
+ "libipld 0.16.0",
  "libp2p",
  "multihash 0.16.3",
  "prometheus",
@@ -1889,6 +1940,17 @@ dependencies = [
  "digest",
  "multihash-derive",
  "sha2",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "multihash"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+dependencies = [
+ "core2",
+ "multihash-derive",
  "unsigned-varint 0.7.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.52"
 fnv = "1.0.7"
 futures = "0.3.19"
 lazy_static = "1.4.0"
-libipld = { version = "0.14.0", default-features = false }
+libipld = { version = "0.16.0", default-features = false }
 libp2p = { version = "0.53", features = ["request-response"] }
 prometheus = "0.13.0"
 prost = { version = "0.9.0", optional = true }


### PR DESCRIPTION
This PR upgrades `libipld` to version 0.16 which is required so we can upgrade `cid` to version 0.10 in the ipc repo